### PR TITLE
Refine UX and bump password limit

### DIFF
--- a/components/WordPasswords/WordPasswords.js
+++ b/components/WordPasswords/WordPasswords.js
@@ -39,7 +39,7 @@ const WordPasswords = () => {
     };
 
     const sepOptions = [
-        { val: '0', txt: 'Numbers, punctuation & symbols' },
+        { val: '0', txt: 'Numbers, punctuation, & symbols' },
         { val: '1', txt: 'Numbers only' },
         { val: '2', txt: 'Punctuation & symbols only' },
         { val: '3', txt: 'None' },
@@ -80,8 +80,6 @@ const WordPasswords = () => {
                 className="password"
                 onClick={(ev) => {
                     copyToClipboard(ev.currentTarget.innerText);
-                    setIsCopied(true);
-                    setTimeout(() => setIsCopied(false), 1000);
                 }}>
                 {buildPassword()}
             </div>
@@ -97,7 +95,10 @@ const WordPasswords = () => {
     const copyToClipboard = (text) => {
         navigator.clipboard
             .writeText(text)
-            .then(() => {})
+            .then(() => {
+                setIsCopied(true);
+                setTimeout(() => setIsCopied(false), 1000);
+            })
             .catch((err) => {
                 console.error('Failed to copy password to clipboard', err);
             });
@@ -150,7 +151,7 @@ const WordPasswords = () => {
                         Number of passwords
                         <br />
                         <select onChange={(ev) => setPasswordLengths(ev.target.value)} defaultValue={passwordsLength}>
-                            {buildOptions(20).map((option) => (
+                            {buildOptions(25).map((option) => (
                                 <option key={option.val} value={option.val}>
                                     {option.txt}
                                 </option>

--- a/components/WordPasswords/word-passwords.scss
+++ b/components/WordPasswords/word-passwords.scss
@@ -29,6 +29,9 @@
             .sep {
                 color: orangered;
             }
+            &:hover {
+                text-decoration: underline;
+            }
         }
         .overlay {
             position: absolute;


### PR DESCRIPTION
Improved user feedback for copy-to-clipboard action by moving the notification trigger into the promise resolution of the clipboard write operation, ensuring users are alerted only upon successful copy. Enhanced clarity in separator options with corrected punctuation. Also increased the maximum option for generated passwords from 20 to 25, allowing users to create longer password sequences for enhanced security.

Refine copy UX and increase password limit

Improved the copy-to-clipboard user experience by displaying a notification only after the text is successfully copied, ensuring accurate user feedback. Tweaked the tooltip text for clarity in separator options. Expanded the password generator's limit from 20 to 25, enhancing security potential for users. Also, added hover effect for password elements to improve UI responsiveness.