### PR TITLE
Refactor overlay handling for password copy

### DIFF
--- a/components/WordPasswords/WordPasswords.js
+++ b/components/WordPasswords/WordPasswords.js
@@ -173,10 +173,7 @@ const WordPasswords = () => {
                         <br />
                         Click a password to copy it to the clipboard.
                     </p>
-                    <section className="results">
-                        {passwordArray}
-                        {isCopied && <div class="overlay">Copied!</div>}
-                    </section>
+                    <section className="results">{passwordArray}</section>
                 </div>
             </div>
             <footer className="row">
@@ -184,6 +181,7 @@ const WordPasswords = () => {
                     <abbr title="Jim Horn">JHo</abbr> :: 2020 - {new Date().getFullYear()}
                 </div>
             </footer>
+            {isCopied && <div class="overlay">Copied!</div>}
         </main>
     );
 };

--- a/components/WordPasswords/word-passwords.scss
+++ b/components/WordPasswords/word-passwords.scss
@@ -33,24 +33,24 @@
                 text-decoration: underline;
             }
         }
-        .overlay {
-            position: absolute;
-            width: 100%;
-            height: 100%;
-            background: rgba(255, 255, 255, 0.75);
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            font-size: 2rem;
-            color: green;
-            line-height: 1;
-            left: 0;
-            top: 0;
-        }
     }
     .copy {
         text-align: center;
         font-size: small;
         margin-bottom: 1rem;
+    }
+    .overlay {
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        background: rgba(255, 255, 255, 0.75);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        font-size: 2rem;
+        color: green;
+        line-height: 1;
+        left: 0;
+        top: 0;
     }
 }


### PR DESCRIPTION
Moved the "Copied!" overlay outside of the results section to ensure consistent UI placement across all scenarios. This change allows the overlay to be displayed independently of the passwords list, avoiding any potential layout shifts when passwords are copied to the clipboard.