### PR TITLE
Updates Parcel dependencies to latest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,15 +21,15 @@
         "react-dom": "18.3.1"
     },
     "devDependencies": {
-        "@parcel/config-default": "^2.13.2",
-        "@parcel/transformer-raw": "^2.13.2",
-        "@parcel/transformer-sass": "2.13.2",
+        "@parcel/config-default": "^2.13.3",
+        "@parcel/transformer-raw": "^2.13.3",
+        "@parcel/transformer-sass": "2.13.3",
         "husky": "9.1.7",
-        "parcel": "^2.13.2",
+        "parcel": "^2.13.3",
         "prettier": "^3.4.2",
         "pretty-quick": "4.0.0",
         "process": "^0.11.10",
         "rimraf": "^6.0.1",
-        "sass": "1.82.0"
+        "sass": "1.83.1"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -109,100 +109,100 @@
   resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz#0aa5502d547b57abfc4ac492de68e2006e417242"
   integrity sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==
 
-"@parcel/bundler-default@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/bundler-default/-/bundler-default-2.13.2.tgz#1c71b36d33aeff02132f568ef2fb288aa7403207"
-  integrity sha512-WY0LB1B7H6zIGXBtwssZRmzk788GzHoOGvMSIqgE/mZ0+jPF5V54zkjbhPBXj1fvoKOGlFy8Bm/gd/GnlQDdIg==
+"@parcel/bundler-default@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/bundler-default/-/bundler-default-2.13.3.tgz#3a7b88f473b46321532dc0f187667f8e34f0722d"
+  integrity sha512-mOuWeth0bZzRv1b9Lrvydis/hAzJyePy0gwa0tix3/zyYBvw0JY+xkXVR4qKyD/blc1Ra2qOlfI2uD3ucnsdXA==
   dependencies:
-    "@parcel/diagnostic" "2.13.2"
-    "@parcel/graph" "3.3.2"
-    "@parcel/plugin" "2.13.2"
-    "@parcel/rust" "2.13.2"
-    "@parcel/utils" "2.13.2"
+    "@parcel/diagnostic" "2.13.3"
+    "@parcel/graph" "3.3.3"
+    "@parcel/plugin" "2.13.3"
+    "@parcel/rust" "2.13.3"
+    "@parcel/utils" "2.13.3"
     nullthrows "^1.1.1"
 
-"@parcel/cache@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/cache/-/cache-2.13.2.tgz#205f994927c98859ad846df3aa7267f62a161cc0"
-  integrity sha512-Y0nWlCMWDSp1lxiPI5zCWTGD0InnVZ+IfqeyLWmROAqValYyd0QZCvnSljKJ144jWTr0jXxDveir+DVF8sAYaA==
+"@parcel/cache@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/cache/-/cache-2.13.3.tgz#ea23b8cc3d30ee7b7e735e4c58dc5294d5bdb437"
+  integrity sha512-Vz5+K5uCt9mcuQAMDo0JdbPYDmVdB8Nvu/A2vTEK2rqZPxvoOTczKeMBA4JqzKqGURHPRLaJCvuR8nDG+jhK9A==
   dependencies:
-    "@parcel/fs" "2.13.2"
-    "@parcel/logger" "2.13.2"
-    "@parcel/utils" "2.13.2"
+    "@parcel/fs" "2.13.3"
+    "@parcel/logger" "2.13.3"
+    "@parcel/utils" "2.13.3"
     lmdb "2.8.5"
 
-"@parcel/codeframe@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/codeframe/-/codeframe-2.13.2.tgz#ab8dacfc27dfc2cfb10e4b588c80b85e32c53340"
-  integrity sha512-qFMiS14orb6QSQj5/J/QN+gJElUfedVAKBTNkp9QB4i8ObdLHDqHRUzFb55ZQJI3G4vsxOOWAOUXGirtLwrxGQ==
+"@parcel/codeframe@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/codeframe/-/codeframe-2.13.3.tgz#1e3cc39f85948cc39e9f10584476ff13c0cd4f58"
+  integrity sha512-L/PQf+PT0xM8k9nc0B+PxxOYO2phQYnbuifu9o4pFRiqVmCtHztP+XMIvRJ2gOEXy3pgAImSPFVJ3xGxMFky4g==
   dependencies:
     chalk "^4.1.2"
 
-"@parcel/compressor-raw@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/compressor-raw/-/compressor-raw-2.13.2.tgz#274582ce5a0a5f76e077a9f1b1ca7f47e6741687"
-  integrity sha512-HX51w7WlgQY2f30p3Le1B5nFsUrtEA1phvWEwQDm1gEC6OPmDrxNsFLWx18JdGlKWTaPYbAGXRMSOjUWU41N9w==
+"@parcel/compressor-raw@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/compressor-raw/-/compressor-raw-2.13.3.tgz#7b479b0b42108433b1c48daa0dab6c6387b7be79"
+  integrity sha512-C6vjDlgTLjYc358i7LA/dqcL0XDQZ1IHXFw6hBaHHOfxPKW2T4bzUI6RURyToEK9Q1X7+ggDKqgdLxwp4veCFg==
   dependencies:
-    "@parcel/plugin" "2.13.2"
+    "@parcel/plugin" "2.13.3"
 
-"@parcel/config-default@2.13.2", "@parcel/config-default@^2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/config-default/-/config-default-2.13.2.tgz#c9e039df0807e967a4671de15fb69ff9879b8ebd"
-  integrity sha512-oTf69/Ikxb7b8uqdu4SasRnIn7e68dCSNW2PhXuBkHq2GgzTSnpSqCwur70wQwrHKHdNt9RtIjLQgC6oOs5aJQ==
+"@parcel/config-default@2.13.3", "@parcel/config-default@^2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/config-default/-/config-default-2.13.3.tgz#2d0498cf56cb162961e07b867d6f958f8aaaec64"
+  integrity sha512-WUsx83ic8DgLwwnL1Bua4lRgQqYjxiTT+DBxESGk1paNm1juWzyfPXEQDLXwiCTcWMQGiXQFQ8OuSISauVQ8dQ==
   dependencies:
-    "@parcel/bundler-default" "2.13.2"
-    "@parcel/compressor-raw" "2.13.2"
-    "@parcel/namer-default" "2.13.2"
-    "@parcel/optimizer-css" "2.13.2"
-    "@parcel/optimizer-htmlnano" "2.13.2"
-    "@parcel/optimizer-image" "2.13.2"
-    "@parcel/optimizer-svgo" "2.13.2"
-    "@parcel/optimizer-swc" "2.13.2"
-    "@parcel/packager-css" "2.13.2"
-    "@parcel/packager-html" "2.13.2"
-    "@parcel/packager-js" "2.13.2"
-    "@parcel/packager-raw" "2.13.2"
-    "@parcel/packager-svg" "2.13.2"
-    "@parcel/packager-wasm" "2.13.2"
-    "@parcel/reporter-dev-server" "2.13.2"
-    "@parcel/resolver-default" "2.13.2"
-    "@parcel/runtime-browser-hmr" "2.13.2"
-    "@parcel/runtime-js" "2.13.2"
-    "@parcel/runtime-react-refresh" "2.13.2"
-    "@parcel/runtime-service-worker" "2.13.2"
-    "@parcel/transformer-babel" "2.13.2"
-    "@parcel/transformer-css" "2.13.2"
-    "@parcel/transformer-html" "2.13.2"
-    "@parcel/transformer-image" "2.13.2"
-    "@parcel/transformer-js" "2.13.2"
-    "@parcel/transformer-json" "2.13.2"
-    "@parcel/transformer-postcss" "2.13.2"
-    "@parcel/transformer-posthtml" "2.13.2"
-    "@parcel/transformer-raw" "2.13.2"
-    "@parcel/transformer-react-refresh-wrap" "2.13.2"
-    "@parcel/transformer-svg" "2.13.2"
+    "@parcel/bundler-default" "2.13.3"
+    "@parcel/compressor-raw" "2.13.3"
+    "@parcel/namer-default" "2.13.3"
+    "@parcel/optimizer-css" "2.13.3"
+    "@parcel/optimizer-htmlnano" "2.13.3"
+    "@parcel/optimizer-image" "2.13.3"
+    "@parcel/optimizer-svgo" "2.13.3"
+    "@parcel/optimizer-swc" "2.13.3"
+    "@parcel/packager-css" "2.13.3"
+    "@parcel/packager-html" "2.13.3"
+    "@parcel/packager-js" "2.13.3"
+    "@parcel/packager-raw" "2.13.3"
+    "@parcel/packager-svg" "2.13.3"
+    "@parcel/packager-wasm" "2.13.3"
+    "@parcel/reporter-dev-server" "2.13.3"
+    "@parcel/resolver-default" "2.13.3"
+    "@parcel/runtime-browser-hmr" "2.13.3"
+    "@parcel/runtime-js" "2.13.3"
+    "@parcel/runtime-react-refresh" "2.13.3"
+    "@parcel/runtime-service-worker" "2.13.3"
+    "@parcel/transformer-babel" "2.13.3"
+    "@parcel/transformer-css" "2.13.3"
+    "@parcel/transformer-html" "2.13.3"
+    "@parcel/transformer-image" "2.13.3"
+    "@parcel/transformer-js" "2.13.3"
+    "@parcel/transformer-json" "2.13.3"
+    "@parcel/transformer-postcss" "2.13.3"
+    "@parcel/transformer-posthtml" "2.13.3"
+    "@parcel/transformer-raw" "2.13.3"
+    "@parcel/transformer-react-refresh-wrap" "2.13.3"
+    "@parcel/transformer-svg" "2.13.3"
 
-"@parcel/core@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/core/-/core-2.13.2.tgz#82cb7d7ccca3d4c689e063e859e6d5942478977c"
-  integrity sha512-1zC5Au4z9or5XyP6ipfvJqHktuB0jD7WuxMcV1CWAZGARHKylLe+0ccl+Wx7HN5O+xAvfCDtTlKrATY8qyrIyw==
+"@parcel/core@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/core/-/core-2.13.3.tgz#d64ec42157a70df6a3674e98f52eb156a103985b"
+  integrity sha512-SRZFtqGiaKHlZ2YAvf+NHvBFWS3GnkBvJMfOJM7kxJRK3M1bhbwJa/GgSdzqro5UVf9Bfj6E+pkdrRQIOZ7jMQ==
   dependencies:
     "@mischnic/json-sourcemap" "^0.1.0"
-    "@parcel/cache" "2.13.2"
-    "@parcel/diagnostic" "2.13.2"
-    "@parcel/events" "2.13.2"
-    "@parcel/feature-flags" "2.13.2"
-    "@parcel/fs" "2.13.2"
-    "@parcel/graph" "3.3.2"
-    "@parcel/logger" "2.13.2"
-    "@parcel/package-manager" "2.13.2"
-    "@parcel/plugin" "2.13.2"
-    "@parcel/profiler" "2.13.2"
-    "@parcel/rust" "2.13.2"
+    "@parcel/cache" "2.13.3"
+    "@parcel/diagnostic" "2.13.3"
+    "@parcel/events" "2.13.3"
+    "@parcel/feature-flags" "2.13.3"
+    "@parcel/fs" "2.13.3"
+    "@parcel/graph" "3.3.3"
+    "@parcel/logger" "2.13.3"
+    "@parcel/package-manager" "2.13.3"
+    "@parcel/plugin" "2.13.3"
+    "@parcel/profiler" "2.13.3"
+    "@parcel/rust" "2.13.3"
     "@parcel/source-map" "^2.1.1"
-    "@parcel/types" "2.13.2"
-    "@parcel/utils" "2.13.2"
-    "@parcel/workers" "2.13.2"
+    "@parcel/types" "2.13.3"
+    "@parcel/utils" "2.13.3"
+    "@parcel/workers" "2.13.3"
     base-x "^3.0.8"
     browserslist "^4.6.6"
     clone "^2.1.1"
@@ -213,309 +213,309 @@
     nullthrows "^1.1.1"
     semver "^7.5.2"
 
-"@parcel/diagnostic@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/diagnostic/-/diagnostic-2.13.2.tgz#f19fddeabb1cbf9522198100a669aedaa172b492"
-  integrity sha512-6Au0JEJ5SY2gYrY0/m0i0sTuqTvK0k2E9azhBJR+zzCREbUxLiDdLZ+vXAfLW7t/kPAcWtdNU0Bj7pnZcMiMXg==
+"@parcel/diagnostic@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/diagnostic/-/diagnostic-2.13.3.tgz#4bc00a915984f8e649a58641d639767d029f72d8"
+  integrity sha512-C70KXLBaXLJvr7XCEVu8m6TqNdw1gQLxqg5BQ8roR62R4vWWDnOq8PEksxDi4Y8Z/FF4i3Sapv6tRx9iBNxDEg==
   dependencies:
     "@mischnic/json-sourcemap" "^0.1.0"
     nullthrows "^1.1.1"
 
-"@parcel/events@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/events/-/events-2.13.2.tgz#5475f63b04e24a890ba33c1e288a5e72df940473"
-  integrity sha512-BVB9hW1RGh/tMaDHfpa+uIgz5PMULorCnjmWr/KvrlhdUSUQoaPYfRcTDYrKhoKuNIKsWSnTGvXrxE53L5qo0w==
+"@parcel/events@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/events/-/events-2.13.3.tgz#068bdd9e1d40f88cb8110d06be2bd4d5fb23c2ad"
+  integrity sha512-ZkSHTTbD/E+53AjUzhAWTnMLnxLEU5yRw0H614CaruGh+GjgOIKyukGeToF5Gf/lvZ159VrJCGE0Z5EpgHVkuQ==
 
-"@parcel/feature-flags@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/feature-flags/-/feature-flags-2.13.2.tgz#09c800973eb463754ec3dd7123226db4ee02a2de"
-  integrity sha512-cCwDAKD4Er24EkuQ+loVZXSURpM0gAGRsLJVoBtFiCSbB3nmIJJ6FLRwSBI/5OsOUExiUXDvSpfUCA5ldGTzbw==
+"@parcel/feature-flags@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/feature-flags/-/feature-flags-2.13.3.tgz#9664d46610a2744dd56677d26cf4fd45ab12928b"
+  integrity sha512-UZm14QpamDFoUut9YtCZSpG1HxPs07lUwUCpsAYL0PpxASD3oWJQxIJGfDZPa2272DarXDG9adTKrNXvkHZblw==
 
-"@parcel/fs@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/fs/-/fs-2.13.2.tgz#75eaf5c5c29d7c2c5393422168c9e88f09d218a5"
-  integrity sha512-bdeIMuAXhMnROvqV55JWRUmjD438/T7h3r3NsFnkq+Mp4z2nuAn0STxbqDNxIgTMJHNunSDzncqRNMT7xJCe8A==
+"@parcel/fs@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/fs/-/fs-2.13.3.tgz#166e7dcdd2afbab201aaf5839f69a8e853da66e0"
+  integrity sha512-+MPWAt0zr+TCDSlj1LvkORTjfB/BSffsE99A9AvScKytDSYYpY2s0t4vtV9unSh0FHMS2aBCZNJ4t7KL+DcPIg==
   dependencies:
-    "@parcel/feature-flags" "2.13.2"
-    "@parcel/rust" "2.13.2"
-    "@parcel/types-internal" "2.13.2"
-    "@parcel/utils" "2.13.2"
+    "@parcel/feature-flags" "2.13.3"
+    "@parcel/rust" "2.13.3"
+    "@parcel/types-internal" "2.13.3"
+    "@parcel/utils" "2.13.3"
     "@parcel/watcher" "^2.0.7"
-    "@parcel/workers" "2.13.2"
+    "@parcel/workers" "2.13.3"
 
-"@parcel/graph@3.3.2":
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/@parcel/graph/-/graph-3.3.2.tgz#d9dcbf8bd3d6fb13fd97ae3103a90008f18b6bfd"
-  integrity sha512-aAysQLRr8SOonSHWqdKHMJzfcrDFXKK8IYZEurlOzosiSgZXrAK7q8b8JcaJ4r84/jlvQYNYneNZeFQxKjHXkA==
+"@parcel/graph@3.3.3":
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/@parcel/graph/-/graph-3.3.3.tgz#9a48d22f8d6c1e961f2723d4d7343f5388b689bb"
+  integrity sha512-pxs4GauEdvCN8nRd6wG3st6LvpHske3GfqGwUSR0P0X0pBPI1/NicvXz6xzp3rgb9gPWfbKXeI/2IOTfIxxVfg==
   dependencies:
-    "@parcel/feature-flags" "2.13.2"
+    "@parcel/feature-flags" "2.13.3"
     nullthrows "^1.1.1"
 
-"@parcel/logger@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/logger/-/logger-2.13.2.tgz#b2b2dc3307fb3ebd5a124ef9e9ca67a53b718459"
-  integrity sha512-SFVABAMqaT9jIDn4maPgaQQauPDz8fpoKUGEuLF44Q0aQFbBUy7vX7KYs/EvYSWZo4VyJcUDHvIInBlepA0/ZQ==
+"@parcel/logger@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/logger/-/logger-2.13.3.tgz#0c91bb7fefa37b5dccd5cdfcd30cf52f5c56a1d9"
+  integrity sha512-8YF/ZhsQgd7ohQ2vEqcMD1Ag9JlJULROWRPGgGYLGD+twuxAiSdiFBpN3f+j4gQN4PYaLaIS/SwUFx11J243fQ==
   dependencies:
-    "@parcel/diagnostic" "2.13.2"
-    "@parcel/events" "2.13.2"
+    "@parcel/diagnostic" "2.13.3"
+    "@parcel/events" "2.13.3"
 
-"@parcel/markdown-ansi@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/markdown-ansi/-/markdown-ansi-2.13.2.tgz#ca54806e783f95261304de0ca96f4f69534a7a03"
-  integrity sha512-MIEoetfT/snk1GqWzBI3AhifV257i2xke9dvyQl14PPiMl+TlVhwnbQyA09WJBvDor+MuxZypHL7xoFdW8ff3A==
+"@parcel/markdown-ansi@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/markdown-ansi/-/markdown-ansi-2.13.3.tgz#05eec8407643d2c36f3511a37c38f08f7b236e24"
+  integrity sha512-B4rUdlNUulJs2xOQuDbN7Hq5a9roq8IZUcJ1vQ8PAv+zMGb7KCfqIIr/BSCDYGhayfAGBVWW8x55Kvrl1zrDYw==
   dependencies:
     chalk "^4.1.2"
 
-"@parcel/namer-default@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/namer-default/-/namer-default-2.13.2.tgz#12e2b21961b93197bc1ee3a5d48fae9ad4aef538"
-  integrity sha512-wHaaJZcZEZUaCylC88PqjN4BybJhnkpP5RYg1xGWBTzdxhZthxvDbeOI+0YZ4jZXrLyVNjPyPRwyx0ETlq8MKA==
+"@parcel/namer-default@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/namer-default/-/namer-default-2.13.3.tgz#a77ce846de8203d2a4b1f93666520b0ac8a90865"
+  integrity sha512-A2a5A5fuyNcjSGOS0hPcdQmOE2kszZnLIXof7UMGNkNkeC62KAG8WcFZH5RNOY3LT5H773hq51zmc2Y2gE5Rnw==
   dependencies:
-    "@parcel/diagnostic" "2.13.2"
-    "@parcel/plugin" "2.13.2"
+    "@parcel/diagnostic" "2.13.3"
+    "@parcel/plugin" "2.13.3"
     nullthrows "^1.1.1"
 
-"@parcel/node-resolver-core@3.4.2":
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/@parcel/node-resolver-core/-/node-resolver-core-3.4.2.tgz#b4e077f82980ea177ad8872c289d9c0853743d72"
-  integrity sha512-SwnKLcZRG1VdB5JeM/Ax5VMWWh2QfXufmMQCKKx0/Kk41nUpie+aIZKj3LH6Z/fJsnKig/vXpeWoxGhmG523qg==
+"@parcel/node-resolver-core@3.4.3":
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/@parcel/node-resolver-core/-/node-resolver-core-3.4.3.tgz#aa254b2f0ac9fd5790bfd353430f19ae3b0ee778"
+  integrity sha512-IEnMks49egEic1ITBp59VQyHzkSQUXqpU9hOHwqN3KoSTdZ6rEgrXcS3pa6tdXay4NYGlcZ88kFCE8i/xYoVCg==
   dependencies:
     "@mischnic/json-sourcemap" "^0.1.0"
-    "@parcel/diagnostic" "2.13.2"
-    "@parcel/fs" "2.13.2"
-    "@parcel/rust" "2.13.2"
-    "@parcel/utils" "2.13.2"
+    "@parcel/diagnostic" "2.13.3"
+    "@parcel/fs" "2.13.3"
+    "@parcel/rust" "2.13.3"
+    "@parcel/utils" "2.13.3"
     nullthrows "^1.1.1"
     semver "^7.5.2"
 
-"@parcel/optimizer-css@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/optimizer-css/-/optimizer-css-2.13.2.tgz#fd2023dee2dbf8407db3784ef7c7d438e84ad016"
-  integrity sha512-V9JszWd1Lk3b/9hpfRp6U8lfOIaFPyevGFNTrT+CFMviuipCMWrkUgBa7wtFvqN1i8IJ5NV5FhIlc12qfBBBgA==
+"@parcel/optimizer-css@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/optimizer-css/-/optimizer-css-2.13.3.tgz#504f75cdfde89f2463d06a8d18fbf861b2a352af"
+  integrity sha512-A8o9IVCv919vhv69SkLmyW2WjJR5WZgcMqV6L1uiGF8i8z18myrMhrp2JuSHx29PRT9uNyzNC4Xrd4StYjIhJg==
   dependencies:
-    "@parcel/diagnostic" "2.13.2"
-    "@parcel/plugin" "2.13.2"
+    "@parcel/diagnostic" "2.13.3"
+    "@parcel/plugin" "2.13.3"
     "@parcel/source-map" "^2.1.1"
-    "@parcel/utils" "2.13.2"
+    "@parcel/utils" "2.13.3"
     browserslist "^4.6.6"
     lightningcss "^1.22.1"
     nullthrows "^1.1.1"
 
-"@parcel/optimizer-htmlnano@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.13.2.tgz#0158b2ad882ce5ff6e4c27d244fac7aa61d80956"
-  integrity sha512-/ikDOZrnO4tdt99h34OyqnNIhugdeqWgnpfqEQ6Xi7odIn8OIGfwAHBXoyKRyUU8YUTqLhzOhckbSMwFTPRmXg==
+"@parcel/optimizer-htmlnano@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.13.3.tgz#eaf0c011806d9856a64d4a96e9a30c970e3e003d"
+  integrity sha512-K4Uvg0Sy2pECP7pdvvbud++F0pfcbNkq+IxTrgqBX5HJnLEmRZwgdvZEKF43oMEolclMnURMQRGjRplRaPdbXg==
   dependencies:
-    "@parcel/diagnostic" "2.13.2"
-    "@parcel/plugin" "2.13.2"
-    "@parcel/utils" "2.13.2"
+    "@parcel/diagnostic" "2.13.3"
+    "@parcel/plugin" "2.13.3"
+    "@parcel/utils" "2.13.3"
     htmlnano "^2.0.0"
     nullthrows "^1.1.1"
     posthtml "^0.16.5"
 
-"@parcel/optimizer-image@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/optimizer-image/-/optimizer-image-2.13.2.tgz#9747b501e88cb600a5ca13062c37185526852328"
-  integrity sha512-1BsQOPoSB0TBJJ40TiN+VS3YK2V4EMDtaOML1Bet2oTLMlL77vJG/xT5QHzhExYK+ZyFh2R0gq7deEKXNScBzg==
+"@parcel/optimizer-image@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/optimizer-image/-/optimizer-image-2.13.3.tgz#7daac3ac2d13c769d84ee0d982132f86296fdde0"
+  integrity sha512-wlDUICA29J4UnqkKrWiyt68g1e85qfYhp4zJFcFJL0LX1qqh1QwsLUz3YJ+KlruoqPxJSFEC8ncBEKiVCsqhEQ==
   dependencies:
-    "@parcel/diagnostic" "2.13.2"
-    "@parcel/plugin" "2.13.2"
-    "@parcel/rust" "2.13.2"
-    "@parcel/utils" "2.13.2"
-    "@parcel/workers" "2.13.2"
+    "@parcel/diagnostic" "2.13.3"
+    "@parcel/plugin" "2.13.3"
+    "@parcel/rust" "2.13.3"
+    "@parcel/utils" "2.13.3"
+    "@parcel/workers" "2.13.3"
 
-"@parcel/optimizer-svgo@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/optimizer-svgo/-/optimizer-svgo-2.13.2.tgz#045f8d744e8dfee4d41c70bdf01792f8a14dd71a"
-  integrity sha512-QbuQzGfk5b/p9Yzc8PaSyjwalZbu/5afrKaLYKkiyG+kAVVOGMsxA2WPqPdb8x551AgdQL4OVODS9dE3zdDQOQ==
+"@parcel/optimizer-svgo@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/optimizer-svgo/-/optimizer-svgo-2.13.3.tgz#8afd39b8903bee52dd98ae349aca7e27e9fcdaa1"
+  integrity sha512-piIKxQKzhZK54dJR6yqIcq+urZmpsfgUpLCZT3cnWlX4ux5+S2iN66qqZBs0zVn+a58LcWcoP4Z9ieiJmpiu2w==
   dependencies:
-    "@parcel/diagnostic" "2.13.2"
-    "@parcel/plugin" "2.13.2"
-    "@parcel/utils" "2.13.2"
+    "@parcel/diagnostic" "2.13.3"
+    "@parcel/plugin" "2.13.3"
+    "@parcel/utils" "2.13.3"
 
-"@parcel/optimizer-swc@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/optimizer-swc/-/optimizer-swc-2.13.2.tgz#b495d336255f00464419b474d471640145f29e09"
-  integrity sha512-tyxXn36UAxZkAh+/cjvWwLCBkY+DL7+4G9NHWl5KeFqErc4diBox81Aiu8hnswNzFIg4ljn6f0rNpnWM3yfoMg==
+"@parcel/optimizer-swc@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/optimizer-swc/-/optimizer-swc-2.13.3.tgz#0ec2a4b8fc87c758fed8aba3a9145d78ac0449e9"
+  integrity sha512-zNSq6oWqLlW8ksPIDjM0VgrK6ZAJbPQCDvs1V+p0oX3CzEe85lT5VkRpnfrN1+/vvEJNGL8e60efHKpI+rXGTA==
   dependencies:
-    "@parcel/diagnostic" "2.13.2"
-    "@parcel/plugin" "2.13.2"
+    "@parcel/diagnostic" "2.13.3"
+    "@parcel/plugin" "2.13.3"
     "@parcel/source-map" "^2.1.1"
-    "@parcel/utils" "2.13.2"
+    "@parcel/utils" "2.13.3"
     "@swc/core" "^1.7.26"
     nullthrows "^1.1.1"
 
-"@parcel/package-manager@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/package-manager/-/package-manager-2.13.2.tgz#9064c5b1163f7fe3f63f63b383942d3ea075f71e"
-  integrity sha512-6HjfbdJUjHyNKzYB7GSYnOCtLwqCGW7yT95GlnnTKyFffvXYsqvBSyepMuPRlbX0mFUm4S9l2DH3OVZrk108AA==
+"@parcel/package-manager@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/package-manager/-/package-manager-2.13.3.tgz#0106ca0f94f569c9fa00f538c5bba6e9ac6e9e37"
+  integrity sha512-FLNI5OrZxymGf/Yln0E/kjnGn5sdkQAxW7pQVdtuM+5VeN75yibJRjsSGv88PvJ+KvpD2ANgiIJo1RufmoPcww==
   dependencies:
-    "@parcel/diagnostic" "2.13.2"
-    "@parcel/fs" "2.13.2"
-    "@parcel/logger" "2.13.2"
-    "@parcel/node-resolver-core" "3.4.2"
-    "@parcel/types" "2.13.2"
-    "@parcel/utils" "2.13.2"
-    "@parcel/workers" "2.13.2"
+    "@parcel/diagnostic" "2.13.3"
+    "@parcel/fs" "2.13.3"
+    "@parcel/logger" "2.13.3"
+    "@parcel/node-resolver-core" "3.4.3"
+    "@parcel/types" "2.13.3"
+    "@parcel/utils" "2.13.3"
+    "@parcel/workers" "2.13.3"
     "@swc/core" "^1.7.26"
     semver "^7.5.2"
 
-"@parcel/packager-css@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/packager-css/-/packager-css-2.13.2.tgz#39b8be194d3855048b16f05a1c8b72b9754627ee"
-  integrity sha512-agao71rIHU1lR776IMwxKvknl1/Yglhkr2qSY0JQC10PRQXHs7nj0GXd69p568W42A3/rkMWrXjWkGzhbAcPRg==
+"@parcel/packager-css@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/packager-css/-/packager-css-2.13.3.tgz#ee3c66884f1c7dc17489cefa63e03d5c57cf4bd7"
+  integrity sha512-ghDqRMtrUwaDERzFm9le0uz2PTeqqsjsW0ihQSZPSAptElRl9o5BR+XtMPv3r7Ui0evo+w35gD55oQCJ28vCig==
   dependencies:
-    "@parcel/diagnostic" "2.13.2"
-    "@parcel/plugin" "2.13.2"
+    "@parcel/diagnostic" "2.13.3"
+    "@parcel/plugin" "2.13.3"
     "@parcel/source-map" "^2.1.1"
-    "@parcel/utils" "2.13.2"
+    "@parcel/utils" "2.13.3"
     lightningcss "^1.22.1"
     nullthrows "^1.1.1"
 
-"@parcel/packager-html@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/packager-html/-/packager-html-2.13.2.tgz#e64ba294c5062209b26ceef3b7f9198e71dbb90b"
-  integrity sha512-RHoYR4sp5VZATQbKE2Rn7DrJKK7HnvUTKB0WPFSppWJbJrqrZgvVCqnBMI2FPkbCoznGdt20rQ1R6vs591fuxQ==
+"@parcel/packager-html@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/packager-html/-/packager-html-2.13.3.tgz#00c080d87cd47d77730b9000224acef864d17abe"
+  integrity sha512-jDLnKSA/EzVEZ3/aegXO3QJ/Ij732AgBBkIQfeC8tUoxwVz5b3HiPBAjVjcUSfZs7mdBSHO+ELWC3UD+HbsIrQ==
   dependencies:
-    "@parcel/plugin" "2.13.2"
-    "@parcel/types" "2.13.2"
-    "@parcel/utils" "2.13.2"
+    "@parcel/plugin" "2.13.3"
+    "@parcel/types" "2.13.3"
+    "@parcel/utils" "2.13.3"
     nullthrows "^1.1.1"
     posthtml "^0.16.5"
 
-"@parcel/packager-js@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/packager-js/-/packager-js-2.13.2.tgz#bb8a5e9eb2f21ac917cccc226897ecbfb0510d2a"
-  integrity sha512-/dx19/vTCb4JIx/556hz6KEmwanasUNLAFsZ1PAm5AYDcoxJtHiNITRilA6JTlO+mdsERxOI5eE7tHCTou1ErQ==
+"@parcel/packager-js@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/packager-js/-/packager-js-2.13.3.tgz#6e9fbb6a8cab064ab7021bb6b73f8934e4bc6576"
+  integrity sha512-0pMHHf2zOn7EOJe88QJw5h/wcV1bFfj6cXVcE55Wa8GX3V+SdCgolnlvNuBcRQ1Tlx0Xkpo+9hMFVIQbNQY6zw==
   dependencies:
-    "@parcel/diagnostic" "2.13.2"
-    "@parcel/plugin" "2.13.2"
-    "@parcel/rust" "2.13.2"
+    "@parcel/diagnostic" "2.13.3"
+    "@parcel/plugin" "2.13.3"
+    "@parcel/rust" "2.13.3"
     "@parcel/source-map" "^2.1.1"
-    "@parcel/types" "2.13.2"
-    "@parcel/utils" "2.13.2"
+    "@parcel/types" "2.13.3"
+    "@parcel/utils" "2.13.3"
     globals "^13.2.0"
     nullthrows "^1.1.1"
 
-"@parcel/packager-raw@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/packager-raw/-/packager-raw-2.13.2.tgz#a30089b8db68e6eeb1820854092a38a988d88491"
-  integrity sha512-P+BnMZ3WS4F+Kpd+iv6PCfgyCftPGf8iGSQOCPkWb5fjuNjfvIzsq4WAW41FPbu788JwChev1O4zREYzlQjG2Q==
+"@parcel/packager-raw@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/packager-raw/-/packager-raw-2.13.3.tgz#89c5bac28f59cbf9ddfb2a561575b3d19e6a021b"
+  integrity sha512-AWu4UB+akBdskzvT3KGVHIdacU9f7cI678DQQ1jKQuc9yZz5D0VFt3ocFBOmvDfEQDF0uH3jjtJR7fnuvX7Biw==
   dependencies:
-    "@parcel/plugin" "2.13.2"
+    "@parcel/plugin" "2.13.3"
 
-"@parcel/packager-svg@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/packager-svg/-/packager-svg-2.13.2.tgz#1b2d1069ab13d41e89b83e4dd94b24127a11dbc7"
-  integrity sha512-K99yyQ1IsbQlGWYOLaxv/GGeWXDq0snbgGrCJvXFS8APZZ2CrXRm2634XLFkY3XA1cKqP47wz+KbibMT/+uaPQ==
+"@parcel/packager-svg@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/packager-svg/-/packager-svg-2.13.3.tgz#aa569e80de31f1869381cd30a7e091c26c31b7a8"
+  integrity sha512-tKGRiFq/4jh5u2xpTstNQ7gu+RuZWzlWqpw5NaFmcKe6VQe5CMcS499xTFoREAGnRvevSeIgC38X1a+VOo+/AA==
   dependencies:
-    "@parcel/plugin" "2.13.2"
-    "@parcel/types" "2.13.2"
-    "@parcel/utils" "2.13.2"
+    "@parcel/plugin" "2.13.3"
+    "@parcel/types" "2.13.3"
+    "@parcel/utils" "2.13.3"
     posthtml "^0.16.4"
 
-"@parcel/packager-wasm@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/packager-wasm/-/packager-wasm-2.13.2.tgz#8202c32c38a894d79d7ed2737957045a30ce8c41"
-  integrity sha512-XqFQQcQRgZLPHgLWsQmWHr47ebsu9F7hmpHS+hFNHda4zj7WDtw7r7n6/d8CEXzdI3agpxR3XKVZzx7nB6sQig==
+"@parcel/packager-wasm@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/packager-wasm/-/packager-wasm-2.13.3.tgz#fa179e5d47e5d96ccf2f9b9170288942afccc7f1"
+  integrity sha512-SZB56/b230vFrSehVXaUAWjJmWYc89gzb8OTLkBm7uvtFtov2J1R8Ig9TTJwinyXE3h84MCFP/YpQElSfoLkJw==
   dependencies:
-    "@parcel/plugin" "2.13.2"
+    "@parcel/plugin" "2.13.3"
 
-"@parcel/plugin@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/plugin/-/plugin-2.13.2.tgz#0020a2c51fd6f4783ba4102fb121345c75512563"
-  integrity sha512-Q+RIENS1B185yLPhrGdzBK1oJrZmh/RXrYMnzJs78Tog8SpihjeNBNR6z4PT85o2F+Gy2y1S9A26fpiGq161qQ==
+"@parcel/plugin@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/plugin/-/plugin-2.13.3.tgz#7542a161672821a1cb104ad09eb58695c53268c8"
+  integrity sha512-cterKHHcwg6q11Gpif/aqvHo056TR+yDVJ3fSdiG2xr5KD1VZ2B3hmofWERNNwjMcnR1h9Xq40B7jCKUhOyNFA==
   dependencies:
-    "@parcel/types" "2.13.2"
+    "@parcel/types" "2.13.3"
 
-"@parcel/profiler@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/profiler/-/profiler-2.13.2.tgz#dfbaf3fd28748f4a201554cfb6d8ab342d708fc9"
-  integrity sha512-fur6Oq2HkX6AiM8rtqmDvldH5JWz0sqXA1ylz8cE3XOiDZIuvCulZmQ+hH+4odaNH6QocI1MwfV+GDh3HlQoCA==
+"@parcel/profiler@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/profiler/-/profiler-2.13.3.tgz#4a375df8f8e1a0a0ab7e73e3562e4e28e9d7cdd7"
+  integrity sha512-ok6BwWSLvyHe5TuSXjSacYnDStFgP5Y30tA9mbtWSm0INDsYf+m5DqzpYPx8U54OaywWMK8w3MXUClosJX3aPA==
   dependencies:
-    "@parcel/diagnostic" "2.13.2"
-    "@parcel/events" "2.13.2"
-    "@parcel/types-internal" "2.13.2"
+    "@parcel/diagnostic" "2.13.3"
+    "@parcel/events" "2.13.3"
+    "@parcel/types-internal" "2.13.3"
     chrome-trace-event "^1.0.2"
 
-"@parcel/reporter-cli@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/reporter-cli/-/reporter-cli-2.13.2.tgz#7a479138992e6424c7fb17cb6d05f9fecf50223b"
-  integrity sha512-dIx4d/B+P+7n+lPCnjorM3ygHf3E/P3os3g6BjUe7gOlq/acTwtM0TNXNdRLcsw3K+RzA2VkHLnvdgjIJ18F5g==
+"@parcel/reporter-cli@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/reporter-cli/-/reporter-cli-2.13.3.tgz#46dcbefeaaf9281cc485fb4b0cc81e2c564abd6a"
+  integrity sha512-EA5tKt/6bXYNMEavSs35qHlFdx6cZmRazlZxPBgxPePQYoouNAPMNLUOEQozaPhz9f5fvNDN7EHOFaAWcdO2LA==
   dependencies:
-    "@parcel/plugin" "2.13.2"
-    "@parcel/types" "2.13.2"
-    "@parcel/utils" "2.13.2"
+    "@parcel/plugin" "2.13.3"
+    "@parcel/types" "2.13.3"
+    "@parcel/utils" "2.13.3"
     chalk "^4.1.2"
     term-size "^2.2.1"
 
-"@parcel/reporter-dev-server@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/reporter-dev-server/-/reporter-dev-server-2.13.2.tgz#60368e91870d8363651a105d27b36153bb9fd408"
-  integrity sha512-alWCPZiXEy5a1/mVnxQTJwJhWrnjaR+JOHQSu69eBGuWHqhXt2SCyKpczT08nm37GIxkhsiIaVR8sP4lVriApw==
+"@parcel/reporter-dev-server@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/reporter-dev-server/-/reporter-dev-server-2.13.3.tgz#af5a9c5f8bf191e03ea95d4cdb59341c9851c83e"
+  integrity sha512-ZNeFp6AOIQFv7mZIv2P5O188dnZHNg0ymeDVcakfZomwhpSva2dFNS3AnvWo4eyWBlUxkmQO8BtaxeWTs7jAuA==
   dependencies:
-    "@parcel/plugin" "2.13.2"
-    "@parcel/utils" "2.13.2"
+    "@parcel/plugin" "2.13.3"
+    "@parcel/utils" "2.13.3"
 
-"@parcel/reporter-tracer@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/reporter-tracer/-/reporter-tracer-2.13.2.tgz#bec863b05bc3cf022ae45e769e013b9872a4f31e"
-  integrity sha512-QdnyUHrYcb5iIMqqp6nmR0xi63sPLTALsRYMoLpQPXP/SrO4JQIqGeBSdHi+59esDnlbWDtN2RpBJ3cXlOsjsA==
+"@parcel/reporter-tracer@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/reporter-tracer/-/reporter-tracer-2.13.3.tgz#4e60b56877d6bf7f0c468b7f75ff57d61ad11a1a"
+  integrity sha512-aBsVPI8jLZTDkFYrI69GxnsdvZKEYerkPsu935LcX9rfUYssOnmmUP+3oI+8fbg+qNjJuk9BgoQ4hCp9FOphMQ==
   dependencies:
-    "@parcel/plugin" "2.13.2"
-    "@parcel/utils" "2.13.2"
+    "@parcel/plugin" "2.13.3"
+    "@parcel/utils" "2.13.3"
     chrome-trace-event "^1.0.3"
     nullthrows "^1.1.1"
 
-"@parcel/resolver-default@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/resolver-default/-/resolver-default-2.13.2.tgz#00032f23097fbad6a18970b4b102caf57e0b96f0"
-  integrity sha512-8bMK04AxUmLF0+rsEl9u2LiboAsTjAemer9N/qMnWfsbxvEDunfTR39fwEEXpGAQV2sFb0ZPYtTxOc8bk5ygcQ==
+"@parcel/resolver-default@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/resolver-default/-/resolver-default-2.13.3.tgz#19987a465ad83a163b3c747e56447c6fd9a905f0"
+  integrity sha512-urBZuRALWT9pFMeWQ8JirchLmsQEyI9lrJptiwLbJWrwvmlwSUGkcstmPwoNRf/aAQjICB7ser/247Vny0pFxA==
   dependencies:
-    "@parcel/node-resolver-core" "3.4.2"
-    "@parcel/plugin" "2.13.2"
+    "@parcel/node-resolver-core" "3.4.3"
+    "@parcel/plugin" "2.13.3"
 
-"@parcel/runtime-browser-hmr@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.13.2.tgz#16e6d94dfe52be9deb988ea93e68a03c6c585473"
-  integrity sha512-ByF8Ww1g6XbtwqBxNZrUz/j9EG0O7sqefkW7E2IWhlxFiNJakIrgaN5VKCBRRWaDvyAz0Kn6Md9e6GLmioRXkA==
+"@parcel/runtime-browser-hmr@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.13.3.tgz#9d2ad14b995b6f357aa4a71e6248defa8d79be5d"
+  integrity sha512-EAcPojQFUNUGUrDk66cu3ySPO0NXRVS5CKPd4QrxPCVVbGzde4koKu8krC/TaGsoyUqhie8HMnS70qBP0GFfcQ==
   dependencies:
-    "@parcel/plugin" "2.13.2"
-    "@parcel/utils" "2.13.2"
+    "@parcel/plugin" "2.13.3"
+    "@parcel/utils" "2.13.3"
 
-"@parcel/runtime-js@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/runtime-js/-/runtime-js-2.13.2.tgz#fa6c100e11a48b7e13c65b7dc40c937b8c942db0"
-  integrity sha512-DxRFW30RWM8noK1+yrqa+GYblMJabx6cg5Q7BI1SmTvVflomYVy2KEBVA161VZoxjHS6o0lToziAeVcUJT5GUQ==
+"@parcel/runtime-js@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/runtime-js/-/runtime-js-2.13.3.tgz#847623b17cb9f2e69db3e860ee1971f591175c27"
+  integrity sha512-62OucNAnxb2Q0uyTFWW/0Hvv2DJ4b5H6neh/YFu2/wmxaZ37xTpEuEcG2do7KW54xE5DeLP+RliHLwi4NvR3ww==
   dependencies:
-    "@parcel/diagnostic" "2.13.2"
-    "@parcel/plugin" "2.13.2"
-    "@parcel/utils" "2.13.2"
+    "@parcel/diagnostic" "2.13.3"
+    "@parcel/plugin" "2.13.3"
+    "@parcel/utils" "2.13.3"
     nullthrows "^1.1.1"
 
-"@parcel/runtime-react-refresh@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.13.2.tgz#aee96cb98ce3dc83502de072225ff53c31c906fb"
-  integrity sha512-anLQUANkU++brMa7PWBmvbGDgaNMA9BP7vg/g22KI7w6nh9D3f4JBi/Vo4N66zHATpex41gAjGmFXcBtotc5bQ==
+"@parcel/runtime-react-refresh@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.13.3.tgz#7d80c130effffabe3977ded470ad7d97401012ea"
+  integrity sha512-PYZ1klpJVwqE3WuifILjtF1dugtesHEuJcXYZI85T6UoRSD5ctS1nAIpZzT14Ga1lRt/jd+eAmhWL1l3m/Vk1Q==
   dependencies:
-    "@parcel/plugin" "2.13.2"
-    "@parcel/utils" "2.13.2"
+    "@parcel/plugin" "2.13.3"
+    "@parcel/utils" "2.13.3"
     react-error-overlay "6.0.9"
     react-refresh ">=0.9 <=0.14"
 
-"@parcel/runtime-service-worker@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/runtime-service-worker/-/runtime-service-worker-2.13.2.tgz#00880c71fb1b85ad52456b4bb76bc30c8cd6a817"
-  integrity sha512-EWn3eM5d81uL9+hXqAnuXo/6yq/7p1VEOKn83FEsbO4TAb6Pd25bJ0mPnWpewPcJBQUoPX3Wjx7VzVit7eeuYw==
+"@parcel/runtime-service-worker@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/runtime-service-worker/-/runtime-service-worker-2.13.3.tgz#759c2fc71614187ea375dac509b7c44f3c4d919c"
+  integrity sha512-BjMhPuT7Us1+YIo31exPRwomPiL+jrZZS5UUAwlEW2XGHDceEotzRM94LwxeFliCScT4IOokGoxixm19qRuzWg==
   dependencies:
-    "@parcel/plugin" "2.13.2"
-    "@parcel/utils" "2.13.2"
+    "@parcel/plugin" "2.13.3"
+    "@parcel/utils" "2.13.3"
     nullthrows "^1.1.1"
 
-"@parcel/rust@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/rust/-/rust-2.13.2.tgz#f04221e811faae4d4fcba99bc935390ca32599e2"
-  integrity sha512-XFIewSwxkrDYOnnSP/XZ1LDLdXTs7L9CjQUWtl46Vir5Pq/rinemwLJeKGIwKLHy7fhUZQjYxquH6fBL+AY8DA==
+"@parcel/rust@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/rust/-/rust-2.13.3.tgz#924ef166e0a16923d01c83df8a65a7a726f77e3a"
+  integrity sha512-dLq85xDAtzr3P5200cvxk+8WXSWauYbxuev9LCPdwfhlaWo/JEj6cu9seVdWlkagjGwkoV1kXC+GGntgUXOLAQ==
 
 "@parcel/source-map@^2.1.1":
   version "2.1.1"
@@ -524,41 +524,41 @@
   dependencies:
     detect-libc "^1.0.3"
 
-"@parcel/transformer-babel@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/transformer-babel/-/transformer-babel-2.13.2.tgz#04503f3bf1886cd8d2b56685d9bd3e91a6d549e8"
-  integrity sha512-2cHXLQ2+jeae+mImoaKTtkKhCKATaPY2+Pao0g3zh1xwhNu/08xj7upnbD548UEyEChUWn6IjWljDsx4y8Oa3w==
+"@parcel/transformer-babel@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/transformer-babel/-/transformer-babel-2.13.3.tgz#a751ccaefd50836be3d01cc2afd5c0982708d5a7"
+  integrity sha512-ikzK9f5WTFrdQsPitQgjCPH6HmVU8AQPRemIJ2BndYhtodn5PQut5cnSvTrqax8RjYvheEKCQk/Zb/uR7qgS3g==
   dependencies:
-    "@parcel/diagnostic" "2.13.2"
-    "@parcel/plugin" "2.13.2"
+    "@parcel/diagnostic" "2.13.3"
+    "@parcel/plugin" "2.13.3"
     "@parcel/source-map" "^2.1.1"
-    "@parcel/utils" "2.13.2"
+    "@parcel/utils" "2.13.3"
     browserslist "^4.6.6"
     json5 "^2.2.0"
     nullthrows "^1.1.1"
     semver "^7.5.2"
 
-"@parcel/transformer-css@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/transformer-css/-/transformer-css-2.13.2.tgz#c79949a3f5a6a251712e3f5bf832c3c37e3cae4e"
-  integrity sha512-QR9I4wYc+Tw7eET5ak3BvXLdsmDJGzq+Gd4KaULa0sNKioDUXCi79E5rGICW8E+BbHGKar7boNzk7HrNZX7PLg==
+"@parcel/transformer-css@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/transformer-css/-/transformer-css-2.13.3.tgz#bb9bfd26798ac955febc7a4eba900a1593321433"
+  integrity sha512-zbrNURGph6JeVADbGydyZ7lcu/izj41kDxQ9xw4RPRW/3rofQiTU0OTREi+uBWiMENQySXVivEdzHA9cA+aLAA==
   dependencies:
-    "@parcel/diagnostic" "2.13.2"
-    "@parcel/plugin" "2.13.2"
+    "@parcel/diagnostic" "2.13.3"
+    "@parcel/plugin" "2.13.3"
     "@parcel/source-map" "^2.1.1"
-    "@parcel/utils" "2.13.2"
+    "@parcel/utils" "2.13.3"
     browserslist "^4.6.6"
     lightningcss "^1.22.1"
     nullthrows "^1.1.1"
 
-"@parcel/transformer-html@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/transformer-html/-/transformer-html-2.13.2.tgz#f4008d18f76fe2b6f301884f9d17e44f04f29a12"
-  integrity sha512-LlQHODz/R832ZuRkCGlOQe+TF1BR9nriUcVSc2Z7q5xQ/HblNPrVvvLDBcXG7xRToawS1y6jXG0Tihv47AykfQ==
+"@parcel/transformer-html@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/transformer-html/-/transformer-html-2.13.3.tgz#969398bdce3f1a295462910976cf2f8d45a83c2d"
+  integrity sha512-Yf74FkL9RCCB4+hxQRVMNQThH9+fZ5w0NLiQPpWUOcgDEEyxTi4FWPQgEBsKl/XK2ehdydbQB9fBgPQLuQxwPg==
   dependencies:
-    "@parcel/diagnostic" "2.13.2"
-    "@parcel/plugin" "2.13.2"
-    "@parcel/rust" "2.13.2"
+    "@parcel/diagnostic" "2.13.3"
+    "@parcel/plugin" "2.13.3"
+    "@parcel/rust" "2.13.3"
     nullthrows "^1.1.1"
     posthtml "^0.16.5"
     posthtml-parser "^0.12.1"
@@ -566,135 +566,135 @@
     semver "^7.5.2"
     srcset "4"
 
-"@parcel/transformer-image@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/transformer-image/-/transformer-image-2.13.2.tgz#a0eb68122bed5316f36b83c6b2e15cfb42817826"
-  integrity sha512-sHk9UmJIPEGil+8ulK+Mi4BArbSuMPTXrY1z3EP4pKGHPCMABNKIRiricngvxCW1eVZrxSokeHQe2jYWJ4tAtA==
+"@parcel/transformer-image@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/transformer-image/-/transformer-image-2.13.3.tgz#e3ee409baa036e5f60036663ad87ff74ff499db3"
+  integrity sha512-wL1CXyeFAqbp2wcEq/JD3a/tbAyVIDMTC6laQxlIwnVV7dsENhK1qRuJZuoBdixESeUpFQSmmQvDIhcfT/cUUg==
   dependencies:
-    "@parcel/plugin" "2.13.2"
-    "@parcel/utils" "2.13.2"
-    "@parcel/workers" "2.13.2"
+    "@parcel/plugin" "2.13.3"
+    "@parcel/utils" "2.13.3"
+    "@parcel/workers" "2.13.3"
     nullthrows "^1.1.1"
 
-"@parcel/transformer-js@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/transformer-js/-/transformer-js-2.13.2.tgz#3efabc2b75189e2373ec11148a5549d0d6305451"
-  integrity sha512-mn5DL+59x0FHeHKWOstZuKcz4rcVnZUAkXMPtERgXa0ggjJ1CgVOc26VD68sszC/aiF6yathz/LJtJpyluniLQ==
+"@parcel/transformer-js@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/transformer-js/-/transformer-js-2.13.3.tgz#e53be3b860fb2dd2430bbd7d1089365492255209"
+  integrity sha512-KqfNGn1IHzDoN2aPqt4nDksgb50Xzcny777C7A7hjlQ3cmkjyJrixYjzzsPaPSGJ+kJpknh3KE8unkQ9mhFvRQ==
   dependencies:
-    "@parcel/diagnostic" "2.13.2"
-    "@parcel/plugin" "2.13.2"
-    "@parcel/rust" "2.13.2"
+    "@parcel/diagnostic" "2.13.3"
+    "@parcel/plugin" "2.13.3"
+    "@parcel/rust" "2.13.3"
     "@parcel/source-map" "^2.1.1"
-    "@parcel/utils" "2.13.2"
-    "@parcel/workers" "2.13.2"
+    "@parcel/utils" "2.13.3"
+    "@parcel/workers" "2.13.3"
     "@swc/helpers" "^0.5.0"
     browserslist "^4.6.6"
     nullthrows "^1.1.1"
     regenerator-runtime "^0.14.1"
     semver "^7.5.2"
 
-"@parcel/transformer-json@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/transformer-json/-/transformer-json-2.13.2.tgz#ef54538b2fcbc69835726d4480122b4e7c03b4c2"
-  integrity sha512-AiLyWPnHaNvO9sGykYF15S3jzyQY0vSw3xQPj/xhDRv7IXQyt3y1zTtJmQsp/ri9vIzf2CruD42UXiaSPpbA8A==
+"@parcel/transformer-json@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/transformer-json/-/transformer-json-2.13.3.tgz#14ae4bcf572babe58a7aa204b7996ceb5a790698"
+  integrity sha512-rrq0ab6J0w9ePtsxi0kAvpCmrUYXXAx1Z5PATZakv89rSYbHBKEdXxyCoKFui/UPVCUEGVs5r0iOFepdHpIyeA==
   dependencies:
-    "@parcel/plugin" "2.13.2"
+    "@parcel/plugin" "2.13.3"
     json5 "^2.2.0"
 
-"@parcel/transformer-postcss@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/transformer-postcss/-/transformer-postcss-2.13.2.tgz#1f535bfe54423006cec6d13292aa298291487ee5"
-  integrity sha512-srcKQcTaaCGutcvpWeTue4/bScPJK3nXyql2QVNneufqxTQsOZcZg8lFaMc3ma6WjQn/m2emQC26eivr3MOhDg==
+"@parcel/transformer-postcss@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/transformer-postcss/-/transformer-postcss-2.13.3.tgz#26d67676ceb313f20097f599628b0da647ea497b"
+  integrity sha512-AIiWpU0QSFBrPcYIqAnhqB8RGE6yHFznnxztfg1t2zMSOnK3xoU6xqYKv8H/MduShGGrC3qVOeDfM8MUwzL3cw==
   dependencies:
-    "@parcel/diagnostic" "2.13.2"
-    "@parcel/plugin" "2.13.2"
-    "@parcel/rust" "2.13.2"
-    "@parcel/utils" "2.13.2"
+    "@parcel/diagnostic" "2.13.3"
+    "@parcel/plugin" "2.13.3"
+    "@parcel/rust" "2.13.3"
+    "@parcel/utils" "2.13.3"
     clone "^2.1.1"
     nullthrows "^1.1.1"
     postcss-value-parser "^4.2.0"
     semver "^7.5.2"
 
-"@parcel/transformer-posthtml@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/transformer-posthtml/-/transformer-posthtml-2.13.2.tgz#fdb070fc5808d29ca4ba6362901221e0e7d9edf7"
-  integrity sha512-pNvxKp7GWLKSbyV2xRaGWZNV/ut8uetMfbwpcGxboxgq5TV9dqnHxRGzsTvZTo7yHqQ3N6hycoGh+w8L/8sg8Q==
+"@parcel/transformer-posthtml@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/transformer-posthtml/-/transformer-posthtml-2.13.3.tgz#2599df5226aa41b9411bcd816bcbfd2a073b8d39"
+  integrity sha512-5GSLyccpHASwFAu3uJ83gDIBSvfsGdVmhJvy0Vxe+K1Fklk2ibhvvtUHMhB7mg6SPHC+R9jsNc3ZqY04ZLeGjw==
   dependencies:
-    "@parcel/plugin" "2.13.2"
-    "@parcel/utils" "2.13.2"
+    "@parcel/plugin" "2.13.3"
+    "@parcel/utils" "2.13.3"
     nullthrows "^1.1.1"
     posthtml "^0.16.5"
     posthtml-parser "^0.12.1"
     posthtml-render "^3.0.0"
     semver "^7.5.2"
 
-"@parcel/transformer-raw@2.13.2", "@parcel/transformer-raw@^2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/transformer-raw/-/transformer-raw-2.13.2.tgz#67c282471868926b8409115fb5df991d96b7bc34"
-  integrity sha512-KsTasFp+jwkGjBLrHO6oiqIIwOeiyNPx5NawmIzXUuGvQv6UhTSayk3NnFxteOVXzy5C9GfrQ5W+IBrHe6JWaw==
+"@parcel/transformer-raw@2.13.3", "@parcel/transformer-raw@^2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/transformer-raw/-/transformer-raw-2.13.3.tgz#6a2eb2201f5dd13c46e10d0aa1c1749d1165e6f3"
+  integrity sha512-BFsAbdQF0l8/Pdb7dSLJeYcd8jgwvAUbHgMink2MNXJuRUvDl19Gns8jVokU+uraFHulJMBj40+K/RTd33in4g==
   dependencies:
-    "@parcel/plugin" "2.13.2"
+    "@parcel/plugin" "2.13.3"
 
-"@parcel/transformer-react-refresh-wrap@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.13.2.tgz#5386bece0e8e3899e1e12ce6faccf1f782cb291c"
-  integrity sha512-2UuuzHzpUx8Z0muoM3cETa7PDRJIG9a5nxPaTBZttT5ucprskITakky5pzsd4gabmNzWfZ5raRG5ixV3zOSL5A==
+"@parcel/transformer-react-refresh-wrap@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.13.3.tgz#45d69ad21940699cf74984bdc74dc8aceb725f65"
+  integrity sha512-mOof4cRyxsZRdg8kkWaFtaX98mHpxUhcGPU+nF9RQVa9q737ItxrorsPNR9hpZAyE2TtFNflNW7RoYsgvlLw8w==
   dependencies:
-    "@parcel/plugin" "2.13.2"
-    "@parcel/utils" "2.13.2"
+    "@parcel/plugin" "2.13.3"
+    "@parcel/utils" "2.13.3"
     react-refresh ">=0.9 <=0.14"
 
-"@parcel/transformer-sass@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/transformer-sass/-/transformer-sass-2.13.2.tgz#22df4c040eebbfcf13d026f844408675dcd2d4b0"
-  integrity sha512-FemdyKa6wvkitG2DQgkDI6NkyJCsQ2My/z3idcFAyf8kb3KBIJ+a0ZK4QALvLnJiC9ugeIKsZk5uFjoJAHX1XQ==
+"@parcel/transformer-sass@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/transformer-sass/-/transformer-sass-2.13.3.tgz#a7b3e0a5639f2318a6cfe8be0220e716e787fb0a"
+  integrity sha512-M8Ntscr+RGoQJ2ymIvT+f/1THea/6pVLJY2ky2N+fhtM6/iFx/7WnpJKL37IKAGIOn5AhqDqc0tPjK6H9moIbA==
   dependencies:
-    "@parcel/plugin" "2.13.2"
+    "@parcel/plugin" "2.13.3"
     "@parcel/source-map" "^2.1.1"
     sass "^1.38.0"
 
-"@parcel/transformer-svg@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/transformer-svg/-/transformer-svg-2.13.2.tgz#fb6b2bdc4c056d298df9af26c5b8c6e6e2e63e84"
-  integrity sha512-ANwWE4/n4rXrlbmY3iT18ndlxlLP1ubapR1wYL9bpp2cKA8ny2tCe5wlzLxBAfwcZx8cd15N/5v/ZwS6xt6BXw==
+"@parcel/transformer-svg@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/transformer-svg/-/transformer-svg-2.13.3.tgz#dabb0f9d23071d36d21e2e460111d5ed0fdb23e3"
+  integrity sha512-9jm7ZF4KHIrGLWlw/SFUz5KKJ20nxHvjFAmzde34R9Wu+F1BOjLZxae7w4ZRwvIc+UVOUcBBQFmhSVwVDZg6Dw==
   dependencies:
-    "@parcel/diagnostic" "2.13.2"
-    "@parcel/plugin" "2.13.2"
-    "@parcel/rust" "2.13.2"
+    "@parcel/diagnostic" "2.13.3"
+    "@parcel/plugin" "2.13.3"
+    "@parcel/rust" "2.13.3"
     nullthrows "^1.1.1"
     posthtml "^0.16.5"
     posthtml-parser "^0.12.1"
     posthtml-render "^3.0.0"
     semver "^7.5.2"
 
-"@parcel/types-internal@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/types-internal/-/types-internal-2.13.2.tgz#01cff2a6875e302646dd2be0b1ffdcc75f620a11"
-  integrity sha512-j0zb3WNM8O/+d8CArll7/4w4AyBED3Jbo32/unz89EPVN0VklmgBrRCAI5QXDKuJAGdAZSL5/a8bNYbwl7/Wxw==
+"@parcel/types-internal@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/types-internal/-/types-internal-2.13.3.tgz#dbbfefeac3ce0e735dcf82bd171115e239d31692"
+  integrity sha512-Lhx0n+9RCp+Ipktf/I+CLm3zE9Iq9NtDd8b2Vr5lVWyoT8AbzBKIHIpTbhLS4kjZ80L3I6o93OYjqAaIjsqoZw==
   dependencies:
-    "@parcel/diagnostic" "2.13.2"
-    "@parcel/feature-flags" "2.13.2"
+    "@parcel/diagnostic" "2.13.3"
+    "@parcel/feature-flags" "2.13.3"
     "@parcel/source-map" "^2.1.1"
     utility-types "^3.10.0"
 
-"@parcel/types@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/types/-/types-2.13.2.tgz#bd7355560cc05f28bf112cd08d1f85fa59bb3762"
-  integrity sha512-6ixqjk2pjKELn4sQ/jdvpbCVTeH6xXQTdotkN8Wzk68F2K2MtSPIRAEocumlexScfffbRQplr2MdIf1JJWLogA==
+"@parcel/types@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/types/-/types-2.13.3.tgz#cb59dd663a945f85eea3764364bb47066023d8a9"
+  integrity sha512-+RpFHxx8fy8/dpuehHUw/ja9PRExC3wJoIlIIF42E7SLu2SvlTHtKm6EfICZzxCXNEBzjoDbamCRcN0nmTPlhw==
   dependencies:
-    "@parcel/types-internal" "2.13.2"
-    "@parcel/workers" "2.13.2"
+    "@parcel/types-internal" "2.13.3"
+    "@parcel/workers" "2.13.3"
 
-"@parcel/utils@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/utils/-/utils-2.13.2.tgz#54989520bf28a0a876ab0c289afb027db29f9ba3"
-  integrity sha512-BkFtRo5xenmonwnBy+X4sVbHIRrx+ZHMPpS/6hFqyTvoUUFq2yTFQnfRGVVOOvscVUxpGom+kewnrTG3HHbZoA==
+"@parcel/utils@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/utils/-/utils-2.13.3.tgz#70199960d84a7c0c0bc813799dd6dab0571e2e59"
+  integrity sha512-yxY9xw2wOUlJaScOXYZmMGoZ4Ck4Kqj+p6Koe5kLkkWM1j98Q0Dj2tf/mNvZi4yrdnlm+dclCwNRnuE8Q9D+pw==
   dependencies:
-    "@parcel/codeframe" "2.13.2"
-    "@parcel/diagnostic" "2.13.2"
-    "@parcel/logger" "2.13.2"
-    "@parcel/markdown-ansi" "2.13.2"
-    "@parcel/rust" "2.13.2"
+    "@parcel/codeframe" "2.13.3"
+    "@parcel/diagnostic" "2.13.3"
+    "@parcel/logger" "2.13.3"
+    "@parcel/markdown-ansi" "2.13.3"
+    "@parcel/rust" "2.13.3"
     "@parcel/source-map" "^2.1.1"
     chalk "^4.1.2"
     nullthrows "^1.1.1"
@@ -788,86 +788,86 @@
     "@parcel/watcher-win32-ia32" "2.5.0"
     "@parcel/watcher-win32-x64" "2.5.0"
 
-"@parcel/workers@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@parcel/workers/-/workers-2.13.2.tgz#86fb8958b3a1840517726987c7ba62d1200e515b"
-  integrity sha512-P78BpH0yTT9KK09wgK4eabtlb5OlcWAmZebOToN5UYuwWEylKt0gWZx1+d+LPQupvK84/iZ+AutDScsATjgUMw==
+"@parcel/workers@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@parcel/workers/-/workers-2.13.3.tgz#781bd062efe9346b7ac9f883b91e8fc6e8f6bda1"
+  integrity sha512-oAHmdniWTRwwwsKbcF4t3VjOtKN+/W17Wj5laiYB+HLkfsjGTfIQPj3sdXmrlBAGpI4omIcvR70PHHXnfdTfwA==
   dependencies:
-    "@parcel/diagnostic" "2.13.2"
-    "@parcel/logger" "2.13.2"
-    "@parcel/profiler" "2.13.2"
-    "@parcel/types-internal" "2.13.2"
-    "@parcel/utils" "2.13.2"
+    "@parcel/diagnostic" "2.13.3"
+    "@parcel/logger" "2.13.3"
+    "@parcel/profiler" "2.13.3"
+    "@parcel/types-internal" "2.13.3"
+    "@parcel/utils" "2.13.3"
     nullthrows "^1.1.1"
 
-"@swc/core-darwin-arm64@1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@swc/core-darwin-arm64/-/core-darwin-arm64-1.10.0.tgz#39fd894356f8e858535e96111d34602da0a730c5"
-  integrity sha512-wCeUpanqZyzvgqWRtXIyhcFK3CqukAlYyP+fJpY2gWc/+ekdrenNIfZMwY7tyTFDkXDYEKzvn3BN/zDYNJFowQ==
+"@swc/core-darwin-arm64@1.10.4":
+  version "1.10.4"
+  resolved "https://registry.yarnpkg.com/@swc/core-darwin-arm64/-/core-darwin-arm64-1.10.4.tgz#86e1998f91af210b3475054aa02f6a16dd8590f6"
+  integrity sha512-sV/eurLhkjn/197y48bxKP19oqcLydSel42Qsy2zepBltqUx+/zZ8+/IS0Bi7kaWVFxerbW1IPB09uq8Zuvm3g==
 
-"@swc/core-darwin-x64@1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@swc/core-darwin-x64/-/core-darwin-x64-1.10.0.tgz#d1b95c1db67ac328a96324b800843bc410d17f05"
-  integrity sha512-0CZPzqTynUBO+SHEl/qKsFSahp2Jv/P2ZRjFG0gwZY5qIcr1+B/v+o74/GyNMBGz9rft+F2WpU31gz2sJwyF4A==
+"@swc/core-darwin-x64@1.10.4":
+  version "1.10.4"
+  resolved "https://registry.yarnpkg.com/@swc/core-darwin-x64/-/core-darwin-x64-1.10.4.tgz#fa9c48aeb8ba2c84263e4027283a10984efabc58"
+  integrity sha512-gjYNU6vrAUO4+FuovEo9ofnVosTFXkF0VDuo1MKPItz6e2pxc2ale4FGzLw0Nf7JB1sX4a8h06CN16/pLJ8Q2w==
 
-"@swc/core-linux-arm-gnueabihf@1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.10.0.tgz#e10510bb028bc3836948cb7345312269cd22295d"
-  integrity sha512-oq+DdMu5uJOFPtRkeiITc4kxmd+QSmK+v+OBzlhdGkSgoH3yRWZP+H2ao0cBXo93ZgCr2LfjiER0CqSKhjGuNA==
+"@swc/core-linux-arm-gnueabihf@1.10.4":
+  version "1.10.4"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.10.4.tgz#4ee8c1dfc95040e265db542ac80d3d7cba6b8b22"
+  integrity sha512-zd7fXH5w8s+Sfvn2oO464KDWl+ZX1MJiVmE4Pdk46N3PEaNwE0koTfgx2vQRqRG4vBBobzVvzICC3618WcefOA==
 
-"@swc/core-linux-arm64-gnu@1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.10.0.tgz#a4826c0b44db5b5a02826a0c47307f5969bcc353"
-  integrity sha512-Y6+PC8knchEViRxiCUj3j8wsGXaIhuvU+WqrFqV834eiItEMEI9+Vh3FovqJMBE3L7d4E4ZQtgImHCXjrHfxbw==
+"@swc/core-linux-arm64-gnu@1.10.4":
+  version "1.10.4"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.10.4.tgz#3b3fc11bb29afa0e79693080d0f0fdf6eb198643"
+  integrity sha512-+UGfoHDxsMZgFD3tABKLeEZHqLNOkxStu+qCG7atGBhS4Slri6h6zijVvf4yI5X3kbXdvc44XV/hrP/Klnui2A==
 
-"@swc/core-linux-arm64-musl@1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.10.0.tgz#d4adab4a646be095e3c64226a0150ebe4b874c1a"
-  integrity sha512-EbrX9A5U4cECCQQfky7945AW9GYnTXtCUXElWTkTYmmyQK87yCyFfY8hmZ9qMFIwxPOH6I3I2JwMhzdi8Qoz7g==
+"@swc/core-linux-arm64-musl@1.10.4":
+  version "1.10.4"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.10.4.tgz#e84c67d5870e0dc1d7c607aebea8b26ea2380dd6"
+  integrity sha512-cDDj2/uYsOH0pgAnDkovLZvKJpFmBMyXkxEG6Q4yw99HbzO6QzZ5HDGWGWVq/6dLgYKlnnmpjZCPPQIu01mXEg==
 
-"@swc/core-linux-x64-gnu@1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.10.0.tgz#278655c2b2abcb2e7ada031e75e6853777ebce4c"
-  integrity sha512-TaxpO6snTjjfLXFYh5EjZ78se69j2gDcqEM8yB9gguPYwkCHi2Ylfmh7iVaNADnDJFtjoAQp0L41bTV/Pfq9Cg==
+"@swc/core-linux-x64-gnu@1.10.4":
+  version "1.10.4"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.10.4.tgz#79a211fa10a33e471cd4a488d4ace50bed79ab02"
+  integrity sha512-qJXh9D6Kf5xSdGWPINpLGixAbB5JX8JcbEJpRamhlDBoOcQC79dYfOMEIxWPhTS1DGLyFakAx2FX/b2VmQmj0g==
 
-"@swc/core-linux-x64-musl@1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.10.0.tgz#7df236de40a685c1723a904d6dead99eea36a30f"
-  integrity sha512-IEGvDd6aEEKEyZFZ8oCKuik05G5BS7qwG5hO5PEMzdGeh8JyFZXxsfFXbfeAqjue4UaUUrhnoX+Ze3M2jBVMHw==
+"@swc/core-linux-x64-musl@1.10.4":
+  version "1.10.4"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.10.4.tgz#e8cb9f27cc7baa1c0d9857491b14dc6479389f44"
+  integrity sha512-A76lIAeyQnHCVt0RL/pG+0er8Qk9+acGJqSZOZm67Ve3B0oqMd871kPtaHBM0BW3OZAhoILgfHW3Op9Q3mx3Cw==
 
-"@swc/core-win32-arm64-msvc@1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.10.0.tgz#99278f8f02c79e03caeeb6d64941d0487e58d7e1"
-  integrity sha512-UkQ952GSpY+Z6XONj9GSW8xGSkF53jrCsuLj0nrcuw7Dvr1a816U/9WYZmmcYS8tnG2vHylhpm6csQkyS8lpCw==
+"@swc/core-win32-arm64-msvc@1.10.4":
+  version "1.10.4"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.10.4.tgz#86e77b35c192ef0a2672c68297685a450c9810cf"
+  integrity sha512-e6j5kBu4fIY7fFxFxnZI0MlEovRvp50Lg59Fw+DVbtqHk3C85dckcy5xKP+UoXeuEmFceauQDczUcGs19SRGSQ==
 
-"@swc/core-win32-ia32-msvc@1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.10.0.tgz#a5cf2cfa3e31e8e01a3692d7e053aaa788d3cf3e"
-  integrity sha512-a2QpIZmTiT885u/mUInpeN2W9ClCnqrV2LnMqJR1/Fgx1Afw/hAtiDZPtQ0SqS8yDJ2VR5gfNZo3gpxWMrqdVA==
+"@swc/core-win32-ia32-msvc@1.10.4":
+  version "1.10.4"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.10.4.tgz#974025ce064066512a036be1f9886cb42e9c99e4"
+  integrity sha512-RSYHfdKgNXV/amY5Tqk1EWVsyQnhlsM//jeqMLw5Fy9rfxP592W9UTumNikNRPdjI8wKKzNMXDb1U29tQjN0dg==
 
-"@swc/core-win32-x64-msvc@1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.10.0.tgz#ee1fdf8e6a627de33501b5a404465a7e676c8689"
-  integrity sha512-tZcCmMwf483nwsEBfUk5w9e046kMa1iSik4bP9Kwi2FGtOfHuDfIcwW4jek3hdcgF5SaBW1ktnK/lgQLDi5AtA==
+"@swc/core-win32-x64-msvc@1.10.4":
+  version "1.10.4"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.10.4.tgz#d68117581947b08015cda617086b36c9a65e983e"
+  integrity sha512-1ujYpaqfqNPYdwKBlvJnOqcl+Syn3UrQ4XE0Txz6zMYgyh6cdU6a3pxqLqIUSJ12MtXRA9ZUhEz1ekU3LfLWXw==
 
 "@swc/core@^1.7.26":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@swc/core/-/core-1.10.0.tgz#9584465f7c5feaf34098466c7063c0044fa08bd8"
-  integrity sha512-+CuuTCmQFfzaNGg1JmcZvdUVITQXJk9sMnl1C2TiDLzOSVOJRwVD4dNo5dljX/qxpMAN+2BIYlwjlSkoGi6grg==
+  version "1.10.4"
+  resolved "https://registry.yarnpkg.com/@swc/core/-/core-1.10.4.tgz#046237f1d207f6f113c724941c148c8f3d40c806"
+  integrity sha512-ut3zfiTLORMxhr6y/GBxkHmzcGuVpwJYX4qyXWuBKkpw/0g0S5iO1/wW7RnLnZbAi8wS/n0atRZoaZlXWBkeJg==
   dependencies:
     "@swc/counter" "^0.1.3"
     "@swc/types" "^0.1.17"
   optionalDependencies:
-    "@swc/core-darwin-arm64" "1.10.0"
-    "@swc/core-darwin-x64" "1.10.0"
-    "@swc/core-linux-arm-gnueabihf" "1.10.0"
-    "@swc/core-linux-arm64-gnu" "1.10.0"
-    "@swc/core-linux-arm64-musl" "1.10.0"
-    "@swc/core-linux-x64-gnu" "1.10.0"
-    "@swc/core-linux-x64-musl" "1.10.0"
-    "@swc/core-win32-arm64-msvc" "1.10.0"
-    "@swc/core-win32-ia32-msvc" "1.10.0"
-    "@swc/core-win32-x64-msvc" "1.10.0"
+    "@swc/core-darwin-arm64" "1.10.4"
+    "@swc/core-darwin-x64" "1.10.4"
+    "@swc/core-linux-arm-gnueabihf" "1.10.4"
+    "@swc/core-linux-arm64-gnu" "1.10.4"
+    "@swc/core-linux-arm64-musl" "1.10.4"
+    "@swc/core-linux-x64-gnu" "1.10.4"
+    "@swc/core-linux-x64-musl" "1.10.4"
+    "@swc/core-win32-arm64-msvc" "1.10.4"
+    "@swc/core-win32-ia32-msvc" "1.10.4"
+    "@swc/core-win32-x64-msvc" "1.10.4"
 
 "@swc/counter@^0.1.3":
   version "0.1.3"
@@ -942,13 +942,13 @@ braces@^3.0.3:
     fill-range "^7.1.1"
 
 browserslist@^4.6.6:
-  version "4.24.2"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.24.2.tgz#f5845bc91069dbd55ee89faf9822e1d885d16580"
-  integrity sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==
+  version "4.24.3"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.24.3.tgz#5fc2725ca8fb3c1432e13dac278c7cc103e026d2"
+  integrity sha512-1CPmv8iobE2fyRMV97dAcMVegvvWKxmq94hkLiAkUGwKVTyDLw33K+ZxiFrREKmmps4rIw6grcCFCnTMSZ/YiA==
   dependencies:
-    caniuse-lite "^1.0.30001669"
-    electron-to-chromium "^1.5.41"
-    node-releases "^2.0.18"
+    caniuse-lite "^1.0.30001688"
+    electron-to-chromium "^1.5.73"
+    node-releases "^2.0.19"
     update-browserslist-db "^1.1.1"
 
 callsites@^3.0.0:
@@ -956,10 +956,10 @@ callsites@^3.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
-caniuse-lite@^1.0.30001669:
-  version "1.0.30001687"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001687.tgz#d0ac634d043648498eedf7a3932836beba90ebae"
-  integrity sha512-0S/FDhf4ZiqrTUiQ39dKeUjYRjkv7lOZU1Dgif2rIqrTzX/1wV2hfKu9TOm1IHkdSijfLswxTFzl/cvir+SLSQ==
+caniuse-lite@^1.0.30001688:
+  version "1.0.30001690"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001690.tgz#f2d15e3aaf8e18f76b2b8c1481abde063b8104c8"
+  integrity sha512-5ExiE3qQN6oF8Clf8ifIDcMRCRE/dMGcETG/XGMD8/XiXm6HXQgQTh1yZYLXXpSOsEUlJm1Xr7kGULZTuGtP/w==
 
 chalk@^4.1.2:
   version "4.1.2"
@@ -970,9 +970,9 @@ chalk@^4.1.2:
     supports-color "^7.1.0"
 
 chokidar@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-4.0.1.tgz#4a6dff66798fb0f72a94f616abbd7e1a19f31d41"
-  integrity sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-4.0.3.tgz#7be37a4c03c9aee1ecfe862a4a23b2c70c205d30"
+  integrity sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==
   dependencies:
     readdirp "^4.0.1"
 
@@ -1079,9 +1079,9 @@ domutils@^2.8.0:
     domhandler "^4.2.0"
 
 domutils@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.1.0.tgz#c47f551278d3dc4b0b1ab8cbb42d751a6f0d824e"
-  integrity sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.2.1.tgz#b39f4c390a1ae6f6a2c56a5f5a16d6438b6bce28"
+  integrity sha512-xWXmuRnN9OMP6ptPd2+H0cCbcYBULa5YDTbMm/2lvkWvNA3O4wcW+GvzooqBuNM8yy6pl3VIAeJTUUWUbfI5Fw==
   dependencies:
     dom-serializer "^2.0.0"
     domelementtype "^2.3.0"
@@ -1104,10 +1104,10 @@ eastasianwidth@^0.2.0:
   resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
   integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
 
-electron-to-chromium@^1.5.41:
-  version "1.5.71"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.71.tgz#d8b5dba1e55b320f2f4e9b1ca80738f53fcfec2b"
-  integrity sha512-dB68l59BI75W1BUGVTAEJy45CEVuEGy9qPVVQ8pnHyHMn36PLPPoE1mjLH+lo9rKulO3HC2OhbACI/8tCqJBcA==
+electron-to-chromium@^1.5.73:
+  version "1.5.76"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.76.tgz#db20295c5061b68f07c8ea4dfcbd701485d94a3d"
+  integrity sha512-CjVQyG7n7Sr+eBXE86HIulnL5N8xZY1sgmOPGuq/F0Rr0FJq63lg0kEtOIDfZBk44FnDLf6FUJ+dsJcuiUDdDQ==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -1541,10 +1541,10 @@ node-gyp-build-optional-packages@5.2.2:
   dependencies:
     detect-libc "^2.0.1"
 
-node-releases@^2.0.18:
-  version "2.0.18"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.18.tgz#f010e8d35e2fe8d6b2944f03f70213ecedc4ca3f"
-  integrity sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==
+node-releases@^2.0.19:
+  version "2.0.19"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.19.tgz#9e445a52950951ec4d177d843af370b411caf314"
+  integrity sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==
 
 npm-run-path@^4.0.1:
   version "4.0.1"
@@ -1589,23 +1589,23 @@ package-json-from-dist@^1.0.0:
   resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz#4f1471a010827a86f94cfd9b0727e36d267de505"
   integrity sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==
 
-parcel@^2.13.2:
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/parcel/-/parcel-2.13.2.tgz#4b138a3c4bf0a5fc63f77345b14cd2f7f06d415f"
-  integrity sha512-ROp1Lf6cihWYzdkieXH+KWVkjlqiUMqW18MBMNZQ3sQitnXWGozTgSYIfpUFLQqaHLgBfm5inOwdqmbzExdpYA==
+parcel@^2.13.3:
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/parcel/-/parcel-2.13.3.tgz#d82c31ecf50169215e31a716b0f8ee5a20bdd865"
+  integrity sha512-8GrC8C7J8mwRpAlk7EJ7lwdFTbCN+dcXH2gy5AsEs9pLfzo9wvxOTx6W0fzSlvCOvZOita+8GdfYlGfEt0tRgA==
   dependencies:
-    "@parcel/config-default" "2.13.2"
-    "@parcel/core" "2.13.2"
-    "@parcel/diagnostic" "2.13.2"
-    "@parcel/events" "2.13.2"
-    "@parcel/feature-flags" "2.13.2"
-    "@parcel/fs" "2.13.2"
-    "@parcel/logger" "2.13.2"
-    "@parcel/package-manager" "2.13.2"
-    "@parcel/reporter-cli" "2.13.2"
-    "@parcel/reporter-dev-server" "2.13.2"
-    "@parcel/reporter-tracer" "2.13.2"
-    "@parcel/utils" "2.13.2"
+    "@parcel/config-default" "2.13.3"
+    "@parcel/core" "2.13.3"
+    "@parcel/diagnostic" "2.13.3"
+    "@parcel/events" "2.13.3"
+    "@parcel/feature-flags" "2.13.3"
+    "@parcel/fs" "2.13.3"
+    "@parcel/logger" "2.13.3"
+    "@parcel/package-manager" "2.13.3"
+    "@parcel/reporter-cli" "2.13.3"
+    "@parcel/reporter-dev-server" "2.13.3"
+    "@parcel/reporter-tracer" "2.13.3"
+    "@parcel/utils" "2.13.3"
     chalk "^4.1.2"
     commander "^12.1.0"
     get-port "^4.2.0"
@@ -1770,10 +1770,10 @@ safe-buffer@^5.0.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
-sass@1.82.0, sass@^1.38.0:
-  version "1.82.0"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.82.0.tgz#30da277af3d0fa6042e9ceabd0d984ed6d07df70"
-  integrity sha512-j4GMCTa8elGyN9A7x7bEglx0VgSpNUG4W4wNedQ33wSMdnkqQCT8HTwOaVSV4e6yQovcu/3Oc4coJP/l0xhL2Q==
+sass@1.83.1, sass@^1.38.0:
+  version "1.83.1"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.83.1.tgz#dee1ab94b47a6f9993d3195d36f556bcbda64846"
+  integrity sha512-EVJbDaEs4Rr3F0glJzFSOvtg2/oy2V/YrGFPqPY24UqcLDWcI9ZY5sN+qyO3c/QCZwzgfirvhXvINiJCE/OLcA==
   dependencies:
     chokidar "^4.0.0"
     immutable "^5.0.2"


### PR DESCRIPTION
Upgrades Parcel and related packages from version 2.13.2 to 2.13.3
and updates SWC core from 1.10.0 to 1.10.4 to ensure compatibility,
fix bugs, and leverage performance improvements. This update also
includes minor enhancements to the browserslist, correcting previous
dependency versions for improved browser support.